### PR TITLE
add default condition to package.exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
     }
   },
   "main": "./dist/index.mjs",


### PR DESCRIPTION
For whatever reason, codesandbox isn't looking at the "import" condition that is Node only. A fix is to give a fallback of "default" which should always work.